### PR TITLE
feature CONF and ROOTFS are both on a LVM LV

### DIFF
--- a/debian/lxctl.init
+++ b/debian/lxctl.init
@@ -30,22 +30,21 @@ fi
 
 start_one() {
   name=$1
-  if [ -f "$CONF_DIR/$name/config" ]; then
-    exec 12<&-
-    if [[ $(grep autostart /etc/lxctl/"$name".yaml | awk '{print $2}') == 1 ]]; then
-      lxctl start $name 
-    fi
-  else
-    log_failure_msg "Can't find config file $CONF_DIR/$name.conf"
+  if [[ $(grep autostart /etc/lxctl/"$name".yaml | awk '{print $2}') == 1 ]]; then
+     lxctl start $name 
   fi
 }
 
 action_all() {
   action=$1
   nolog=$2
-  for i in $(lxctl list --noheader --columns name | xargs); do
+  for i in /etc/lxctl/*.yaml; do
+    name=$(grep contname $i|awk '{print $2}')
+    if [ "$name" = "" ]; then
+       continue 
+    fi
     [ -n "$nolog" ] || log_progress_msg "$i"
-    $action $i
+    $action $name
   done
   [ -n "$nolog" ] || log_end_msg 0
 }


### PR DESCRIPTION
A quick fix to enable debian init script in that situation :
both CONFDIR and ROOTFS are on a lvm LV
The FS needs to be mounted in order to get config file for each VM.

Regards,
Guillaume
