### PR TITLE
Fixed unmounting all mountpoints on stopping container

### DIFF
--- a/src/lib/Lxctl/mount.pm
+++ b/src/lib/Lxctl/mount.pm
@@ -28,6 +28,9 @@ sub add
 	$options{'from'} || die "Don't know what to mount.\n\n";
 	$options{'to'} || die "Don't know where to mount.\n\n";
 
+	# Strip ending slashes
+	$options{'to'} =~ s/\/*$//g;
+
         -e $options{'from'} || $options{'from'} =~ m/^UUID/ || die "You are trying to mount void. Lxctl does not able to do it. Yet.\n\n";
 
 	if (!defined($options{'mountoptions'})) {

--- a/src/lib/Lxctl/stop.pm
+++ b/src/lib/Lxctl/stop.pm
@@ -21,6 +21,14 @@ sub do
 	$options{'contname'} = shift
 		or die "Name the container please!\n\n";
 
+	eval {
+		$self->{'lxc'}->stop($options{'contname'});
+		print "It seems that \"$options{'contname'}\" is stopped now\n";
+	} or do {
+		print "$@";
+		die "Cannot stop $options{'contname'}!\n\n";
+	};
+
 	my $vm_option_ref;
 	my %vm_options;
 	$vm_option_ref = $config->load_file("$yaml_conf_dir/$options{'contname'}.yaml");
@@ -29,45 +37,40 @@ sub do
 	my @mount_points;
 	my $mount_result = `mount`;
 
-	if (defined $vm_options{'mountpoints'}) { 
-                my $mount_ref = $vm_options{'mountpoints'};
+	if (defined $vm_options{'mountpoints'}) {
+		my $mount_ref = $vm_options{'mountpoints'};
 
-                @mount_points = @$mount_ref;
-                if ($#mount_points == -1 ) {
-                        #print "No mount points specified!\n";
-                        last;
-                }
+		@mount_points = @$mount_ref;
+		if ($#mount_points == -1 ) {
+			#print "No mount points specified!\n";
+			last;
+		}
 
-                foreach my $mp_ref (@mount_points) {
-                        my %mp = %$mp_ref;
-                        my $cmd = "umount";
-                        my $to = quotemeta("$root_path/$options{'contname'}/rootfs$mp{'to'}");
+		foreach my $mp_ref (@mount_points) {
+			my %mp = %$mp_ref;
+			my $cmd = "umount";
+			my $to = quotemeta("$root_path/$options{'contname'}/rootfs$mp{'to'}");
 
-                        if ($mount_result =~ /on $to/) {
+			if ($mount_result =~ /on $to/) {
 				$cmd .= " $to";
 				system("$cmd");
 				if ( $? != 0 ) {
 					print "Can't umount $mp{'to'} !";
 				}
 			}
-                }
+		}
 	}
 
 	if (defined $vm_options{'rootfs_mp'}{'to'}) {
-		my $cmd = "umount $vm_options{'rootfs_mp'}{'to'}";
-		system("$cmd");
-		if ( $? != 0 ) {
-			print "Can't umount $vm_options{'rootfs_mp'}{'to'} !";
-		} 
+		my $to = quotemeta("$root_path/$options{'contname'}/rootfs");
+		if ($mount_result =~ /on $to/) {
+			my $cmd = "umount $vm_options{'rootfs_mp'}{'to'}";
+			system("$cmd");
+			if ( $? != 0 ) {
+				print "Can't umount $vm_options{'rootfs_mp'}{'to'} !";
+			}
+		}
 	}
-
-	eval {
-		$self->{'lxc'}->stop($options{'contname'});
-		print "It seems that \"$options{'contname'}\" is stopped now\n";
-	} or do {
-		print "$@";
-		die "Cannot stop $options{'contname'}!\n\n";
-	};
 
 	return;
 }


### PR DESCRIPTION
Lxctl tried to unmount rootfs mountpoint and internal mountpoints _before_ stopping container, so it cannot be achieved. It was look like this:

root@lxc01:~# lxctl stop wiki
umount: /var/lxc/root/wiki: device is busy.
        (In some cases useful info about processes that use
         the device is found by lsof(8) or fuser(1))
Can't umount /var/lxc/root/wiki !It seems that "wiki" is stopped now

Now Lxctl firstly tries to stop container and after that it tries to umount all mountpoints, internal and rootfs.

Another fix is about trailing slash in mountpoint. If you specified mountpoint containing trailing slash you cannot umount that mountpoint on stop. Now trailing slashes in --to option are stripped in mount module.
