### PR TITLE
Fixed umounting mountpoints at container stop.

### DIFF
--- a/src/lib/Lxctl/stop.pm
+++ b/src/lib/Lxctl/stop.pm
@@ -62,7 +62,7 @@ sub do
 	}
 
 	if (defined $vm_options{'rootfs_mp'}{'to'}) {
-		my $to = quotemeta("$root_path/$options{'contname'}/rootfs");
+		my $to = quotemeta("$vm_options{'rootfs_mp'}{'to'}");
 		if ($mount_result =~ /on $to/) {
 			my $cmd = "umount $vm_options{'rootfs_mp'}{'to'}";
 			system("$cmd");


### PR DESCRIPTION
Again fix for this feature. :)
Umounting didn't work in previous revision because there are following lines in 'mount' for containers:

/dev/mapper/blah on /var/lxc/root/blah type ext4 (rw,noatime,barrier=0)

and variable $root_path/$options{'contname'}/rootfs contains:

/var/lxc/root/blah/rootfs

Of course it would never be found in 'mount' output.
Also it's quite a bad idea to hardcode 'rootfs' dir rather than use option from config file.
