### PR TITLE
* added --continue key to lxctl migrate

### DIFF
--- a/src/etc/bash_completion.d/lxctl_migrate
+++ b/src/etc/bash_completion.d/lxctl_migrate
@@ -1,3 +1,3 @@
 LXCTL_PLUGINS="$LXCTL_PLUGINS migrate"
-LXCTL_PLUGIN_migrate="--rootsz --tohost --remuser --remport --remname --afterstart --delete --clone"
+LXCTL_PLUGIN_migrate="--rootsz --tohost --remuser --remport --remname --afterstart --delete --clone --continue"
 LXCTL_PLUGIN_USE_VMNAME_migrate="yes"


### PR DESCRIPTION
If used, lxctl migrate starts from second rsync pass. Useful if lxctl migrate was interrupted for some reason.
