### PR TITLE
move main config from create.pm to /etc/lxctl/conf.d/00-main.conf and…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+lxctl (0.3.11) trusty; urgency=low
+
+  * removed default config from create.pm. New place /etc/lxctl/conf.d/00-main.conf
+  * include configs from /etc/lxctl/conf.d/*.conf (00-main.conf by default)
+
+ -- Vyacheslav Agapov <vyacheslav@yandex-team.ru>  Tue, 25 Oct 2016 17:01:24 +0300
+
+lxctl (0.3.10) precise; urgency=low
+
+  * Added '--roottype raw' option for installing container to raw storage
+    device
+
+ -- Migalin Daniil <dmiga@yandex-team.ru>  Tue, 15 Jul 2014 14:21:25 +0400
+
 lxctl (0.3.9) precise; urgency=low
 
   * fixed previous fix :)

--- a/debian/dirs
+++ b/debian/dirs
@@ -5,3 +5,5 @@
 /usr/lib/perl/5.10/LxctlHelpers
 /var/lxc/templates
 /var/lxc/root
+/etc/lxctl
+/etc/lxctl/conf.d

--- a/debian/install
+++ b/debian/install
@@ -1,5 +1,6 @@
 src/bin/lxctl /usr/bin/
 src/etc/lxctl.yaml /etc/lxctl/
+src/etc/00-main.conf /etc/lxctl/conf.d/
 src/etc/bash_completion.d/* /etc/bash_completion.d/
 src/lib/Lxc/*.pm /usr/share/perl5/Lxc/
 src/lib/Lxctl/*.pm /usr/share/perl5/Lxctl/

--- a/src/etc/00-main.conf
+++ b/src/etc/00-main.conf
@@ -1,0 +1,29 @@
+lxc.utsname = _CT_NAME_
+
+lxc.tty = 4
+lxc.pts = 1024
+lxc.rootfs = _ROOTFS_PATH_
+lxc.mount  = _MOUNT_FSTAB_
+
+lxc.cgroup.devices.deny = a
+# /dev/null and zero
+lxc.cgroup.devices.allow = c 1:3 rwm
+lxc.cgroup.devices.allow = c 1:5 rwm
+# consoles
+lxc.cgroup.devices.allow = c 5:1 rwm
+lxc.cgroup.devices.allow = c 5:0 rwm
+lxc.cgroup.devices.allow = c 4:0 rwm
+lxc.cgroup.devices.allow = c 4:1 rwm
+# /dev/{,u}random
+lxc.cgroup.devices.allow = c 1:9 rwm
+lxc.cgroup.devices.allow = c 1:8 rwm
+lxc.cgroup.devices.allow = c 136:* rwm
+lxc.cgroup.devices.allow = c 5:2 rwm
+# rtc
+lxc.cgroup.devices.allow = c 254:0 rwm
+
+lxc.network.type = veth
+lxc.network.flags = up
+lxc.network.link = br0
+lxc.network.name = eth0
+lxc.network.mtu = 1500


### PR DESCRIPTION
… include other configs from /etc/lxctl/conf.d/*.conf

Вынес конфиг из create.pm. По умолчанию, будет использоваться только 00-main.conf, который будет приезжать в пакете, отдельным файлом. Но можно будет также подкладывать и другие конфиги, которые хочется заиспользовать. Например, это позволит подключить lxcfs, если понадобится.