### PR TITLE
fix crash in 'lxctl list'

### DIFF
--- a/src/lib/Lxc/object.pm
+++ b/src/lib/Lxc/object.pm
@@ -383,6 +383,7 @@ sub ls {
 	my $confpath;
 	my $tmp;
 	my $key;
+	my @netstat;
 	my $subname = (caller(0))[3];
 
 	opendir (my $vm_dir, $self->{LXC_CONF_DIR}) or die "$subname: $self->{LXC_CONF_DIR}: $!";
@@ -397,12 +398,13 @@ sub ls {
 	}
 
 	# Listing all running vm and defining key in hash for them
-	@list = `netstat -xa`;
-	@list = grep /$self->{LXC_CONF_DIR}/, @list;
-	foreach $key (@list)
+	@netstat = `netstat -xa`;
+	foreach my $line (@netstat)
 	{
-		($tmp) = $key =~ m%$self->{LXC_CONF_DIR}/(.*)/command%;
-		$vms{$tmp} = '';
+		($tmp) = $line =~ m%$self->{LXC_CONF_DIR}/(.*)/command%;
+		if (defined($tmp)) {
+			$vms{$tmp} = '';
+		}
 	}
 
 	@list = sort keys %vms;


### PR DESCRIPTION
Sometimes command "lxctl list" crashes like this:
```
# lxctl list
Use of uninitialized value $tmp in hash element at /usr/share/perl5/Lxc/object.pm line 405.
Failed to load YAML document from '/etc/lxctl/.yaml' at /usr/share/perl5/LxctlHelpers/config.pm line 149.
```
The reason is that lxctl get unexpected lines in "netstat -xa" like this:
`unix  2      [ ACC ]     STREAM     LISTENING     161784312 @lxc/ad055575fe28ddd5//var/lib/lxc`
and search for vm name fails.
To be honest, I don't known what this id means, but definetely this patch should fix the problem.